### PR TITLE
Add support for attributes (with no parameters)

### DIFF
--- a/Luau.YAML-tmLanguage
+++ b/Luau.YAML-tmLanguage
@@ -33,6 +33,7 @@ patterns:
   - include: "#table"
   - include: "#type_cast"
   - include: "#type_annotation"
+  - include: "#attribute"
 
 repository:
   function-definition:
@@ -78,6 +79,7 @@ repository:
       "1": { name: storage.modifier.local.luau }
     patterns:
       - include: "#comment"
+      - include: "#attribute"
       - begin: "(:)"
         beginCaptures:
           "1": { name: keyword.operator.type.luau }
@@ -398,3 +400,12 @@ repository:
               "1": { name: variable.parameter.luau }
               "2": { name: keyword.operator.type.luau }
           - include: "#type_literal"
+
+  attribute:
+    patterns:
+      # TODO: support parameters for attributes as defined in the RFC
+      - name: meta.attribute.luau
+        match: "(@)({{identifier}})"
+        captures:
+          "1": { name: keyword.operator.attribute.luau }
+          "2": { name: storage.type.attribute.luau}

--- a/Luau.tmLanguage
+++ b/Luau.tmLanguage
@@ -86,6 +86,10 @@
         <key>include</key>
         <string>#type_annotation</string>
       </dict>
+      <dict>
+        <key>include</key>
+        <string>#attribute</string>
+      </dict>
     </array>
     <key>repository</key>
     <dict>
@@ -223,6 +227,10 @@
           <dict>
             <key>include</key>
             <string>#comment</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#attribute</string>
           </dict>
           <dict>
             <key>begin</key>
@@ -1135,6 +1143,31 @@
                 <string>#type_literal</string>
               </dict>
             </array>
+          </dict>
+        </array>
+      </dict>
+      <key>attribute</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>name</key>
+            <string>meta.attribute.luau</string>
+            <key>match</key>
+            <string>(@)([a-zA-Z_][a-zA-Z0-9_]*)</string>
+            <key>captures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.operator.attribute.luau</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>storage.type.attribute.luau</string>
+              </dict>
+            </dict>
           </dict>
         </array>
       </dict>

--- a/Luau.tmLanguage.json
+++ b/Luau.tmLanguage.json
@@ -60,6 +60,9 @@
     },
     {
       "include": "#type_annotation"
+    },
+    {
+      "include": "#attribute"
     }
   ],
   "repository": {
@@ -149,6 +152,9 @@
       "patterns": [
         {
           "include": "#comment"
+        },
+        {
+          "include": "#attribute"
         },
         {
           "begin": "(:)",
@@ -747,6 +753,22 @@
               "include": "#type_literal"
             }
           ]
+        }
+      ]
+    },
+    "attribute": {
+      "patterns": [
+        {
+          "name": "meta.attribute.luau",
+          "match": "(@)([a-zA-Z_][a-zA-Z0-9_]*)",
+          "captures": {
+            "1": {
+              "name": "keyword.operator.attribute.luau"
+            },
+            "2": {
+              "name": "storage.type.attribute.luau"
+            }
+          }
         }
       ]
     }

--- a/tests/baselines/attribute-function-no-param.baseline.txt
+++ b/tests/baselines/attribute-function-no-param.baseline.txt
@@ -1,0 +1,300 @@
+original file
+-----------------------------------
+@attr_1 @attr_2
+local function a()
+end
+
+local b = @attr_1 @attr_2 function() end
+
+c(@attr_1 @attr_2 function() end)
+
+@attr_1
+local function d()
+end
+
+local e = @attr_1 function() end
+
+f(@attr_1 function() end)
+
+@attr_1 @attr_2 local function g() end
+@attr1 local function h() end
+
+---@doc_comment
+@attr_1
+local function i() end
+-----------------------------------
+
+>@attr_1 @attr_2
+ ^
+ source.luau meta.attribute.luau keyword.operator.attribute.luau
+  ^^^^^^
+  source.luau meta.attribute.luau storage.type.attribute.luau
+        ^
+        source.luau
+         ^
+         source.luau meta.attribute.luau keyword.operator.attribute.luau
+          ^^^^^^
+          source.luau meta.attribute.luau storage.type.attribute.luau
+>local function a()
+ ^^^^^
+ source.luau meta.function.luau storage.modifier.local.luau
+      ^
+      source.luau meta.function.luau
+       ^^^^^^^^
+       source.luau meta.function.luau keyword.control.luau
+               ^
+               source.luau meta.function.luau
+                ^
+                source.luau meta.function.luau entity.name.function.luau
+                 ^
+                 source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.begin.luau
+                  ^
+                  source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.end.luau
+>end
+ ^^^
+ source.luau keyword.control.luau
+>
+ ^
+ source.luau
+>local b = @attr_1 @attr_2 function() end
+ ^^^^^
+ source.luau storage.modifier.local.luau
+      ^
+      source.luau
+       ^
+       source.luau variable.other.readwrite.luau
+        ^
+        source.luau
+         ^
+         source.luau keyword.operator.assignment.luau
+          ^
+          source.luau
+           ^
+           source.luau meta.attribute.luau keyword.operator.attribute.luau
+            ^^^^^^
+            source.luau meta.attribute.luau storage.type.attribute.luau
+                  ^
+                  source.luau
+                   ^
+                   source.luau meta.attribute.luau keyword.operator.attribute.luau
+                    ^^^^^^
+                    source.luau meta.attribute.luau storage.type.attribute.luau
+                          ^
+                          source.luau
+                           ^^^^^^^^
+                           source.luau meta.function.luau keyword.control.luau
+                                   ^
+                                   source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.begin.luau
+                                    ^
+                                    source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.end.luau
+                                     ^
+                                     source.luau
+                                      ^^^
+                                      source.luau keyword.control.luau
+>
+ ^
+ source.luau
+>c(@attr_1 @attr_2 function() end)
+ ^
+ source.luau entity.name.function.luau
+  ^
+  source.luau punctuation.arguments.begin.luau
+   ^
+   source.luau meta.attribute.luau keyword.operator.attribute.luau
+    ^^^^^^
+    source.luau meta.attribute.luau storage.type.attribute.luau
+          ^
+          source.luau
+           ^
+           source.luau meta.attribute.luau keyword.operator.attribute.luau
+            ^^^^^^
+            source.luau meta.attribute.luau storage.type.attribute.luau
+                  ^
+                  source.luau
+                   ^^^^^^^^
+                   source.luau meta.function.luau keyword.control.luau
+                           ^
+                           source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.begin.luau
+                            ^
+                            source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.end.luau
+                             ^
+                             source.luau
+                              ^^^
+                              source.luau keyword.control.luau
+                                 ^
+                                 source.luau punctuation.arguments.end.luau
+>
+ ^
+ source.luau
+>@attr_1
+ ^
+ source.luau meta.attribute.luau keyword.operator.attribute.luau
+  ^^^^^^
+  source.luau meta.attribute.luau storage.type.attribute.luau
+>local function d()
+ ^^^^^
+ source.luau meta.function.luau storage.modifier.local.luau
+      ^
+      source.luau meta.function.luau
+       ^^^^^^^^
+       source.luau meta.function.luau keyword.control.luau
+               ^
+               source.luau meta.function.luau
+                ^
+                source.luau meta.function.luau entity.name.function.luau
+                 ^
+                 source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.begin.luau
+                  ^
+                  source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.end.luau
+>end
+ ^^^
+ source.luau keyword.control.luau
+>
+ ^
+ source.luau
+>local e = @attr_1 function() end
+ ^^^^^
+ source.luau storage.modifier.local.luau
+      ^
+      source.luau
+       ^
+       source.luau variable.other.readwrite.luau
+        ^
+        source.luau
+         ^
+         source.luau keyword.operator.assignment.luau
+          ^
+          source.luau
+           ^
+           source.luau meta.attribute.luau keyword.operator.attribute.luau
+            ^^^^^^
+            source.luau meta.attribute.luau storage.type.attribute.luau
+                  ^
+                  source.luau
+                   ^^^^^^^^
+                   source.luau meta.function.luau keyword.control.luau
+                           ^
+                           source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.begin.luau
+                            ^
+                            source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.end.luau
+                             ^
+                             source.luau
+                              ^^^
+                              source.luau keyword.control.luau
+>
+ ^
+ source.luau
+>f(@attr_1 function() end)
+ ^
+ source.luau entity.name.function.luau
+  ^
+  source.luau punctuation.arguments.begin.luau
+   ^
+   source.luau meta.attribute.luau keyword.operator.attribute.luau
+    ^^^^^^
+    source.luau meta.attribute.luau storage.type.attribute.luau
+          ^
+          source.luau
+           ^^^^^^^^
+           source.luau meta.function.luau keyword.control.luau
+                   ^
+                   source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.begin.luau
+                    ^
+                    source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.end.luau
+                     ^
+                     source.luau
+                      ^^^
+                      source.luau keyword.control.luau
+                         ^
+                         source.luau punctuation.arguments.end.luau
+>
+ ^
+ source.luau
+>@attr_1 @attr_2 local function g() end
+ ^
+ source.luau meta.attribute.luau keyword.operator.attribute.luau
+  ^^^^^^
+  source.luau meta.attribute.luau storage.type.attribute.luau
+        ^
+        source.luau
+         ^
+         source.luau meta.attribute.luau keyword.operator.attribute.luau
+          ^^^^^^
+          source.luau meta.attribute.luau storage.type.attribute.luau
+                ^
+                source.luau
+                 ^^^^^
+                 source.luau meta.function.luau storage.modifier.local.luau
+                      ^
+                      source.luau meta.function.luau
+                       ^^^^^^^^
+                       source.luau meta.function.luau keyword.control.luau
+                               ^
+                               source.luau meta.function.luau
+                                ^
+                                source.luau meta.function.luau entity.name.function.luau
+                                 ^
+                                 source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.begin.luau
+                                  ^
+                                  source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.end.luau
+                                   ^
+                                   source.luau
+                                    ^^^
+                                    source.luau keyword.control.luau
+>@attr1 local function h() end
+ ^
+ source.luau meta.attribute.luau keyword.operator.attribute.luau
+  ^^^^^
+  source.luau meta.attribute.luau storage.type.attribute.luau
+       ^
+       source.luau
+        ^^^^^
+        source.luau meta.function.luau storage.modifier.local.luau
+             ^
+             source.luau meta.function.luau
+              ^^^^^^^^
+              source.luau meta.function.luau keyword.control.luau
+                      ^
+                      source.luau meta.function.luau
+                       ^
+                       source.luau meta.function.luau entity.name.function.luau
+                        ^
+                        source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.begin.luau
+                         ^
+                         source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.end.luau
+                          ^
+                          source.luau
+                           ^^^
+                           source.luau keyword.control.luau
+>
+ ^
+ source.luau
+>---@doc_comment
+ ^^^
+ source.luau comment.line.double-dash.documentation.luau
+    ^^^^^^^^^^^^
+    source.luau comment.line.double-dash.documentation.luau storage.type.class.luadoc.luau
+>@attr_1
+ ^
+ source.luau meta.attribute.luau keyword.operator.attribute.luau
+  ^^^^^^
+  source.luau meta.attribute.luau storage.type.attribute.luau
+>local function i() end
+ ^^^^^
+ source.luau meta.function.luau storage.modifier.local.luau
+      ^
+      source.luau meta.function.luau
+       ^^^^^^^^
+       source.luau meta.function.luau keyword.control.luau
+               ^
+               source.luau meta.function.luau
+                ^
+                source.luau meta.function.luau entity.name.function.luau
+                 ^
+                 source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.begin.luau
+                  ^
+                  source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.end.luau
+                   ^
+                   source.luau
+                    ^^^
+                    source.luau keyword.control.luau

--- a/tests/cases/attribute-function-no-param.luau
+++ b/tests/cases/attribute-function-no-param.luau
@@ -1,0 +1,22 @@
+@attr_1 @attr_2
+local function a()
+end
+
+local b = @attr_1 @attr_2 function() end
+
+c(@attr_1 @attr_2 function() end)
+
+@attr_1
+local function d()
+end
+
+local e = @attr_1 function() end
+
+f(@attr_1 function() end)
+
+@attr_1 @attr_2 local function g() end
+@attr1 local function h() end
+
+---@doc_comment
+@attr_1
+local function i() end


### PR DESCRIPTION
As of the last Luau release ([v630](https://github.com/luau-lang/luau/releases/tag/0.630)), there exists support for attributes. This PR adds support for them to this grammar file.

Of note is that in Luau, attributes are currently supported only for functions. This grammar doesn't attempt to stick to that though, since allowing something *only* before a function declaration seems needlessly complicated. I'm more than willing to change it however, since it's technically incorrect.

This RFC also doesn't add support for attribute parameters as defined in [this RFC](https://rfcs.luau-lang.org/syntax-attributes-functions-parameters.html). The reasoning is that they currently don't exist in Luau, so supporting them in the grammar seems like it is jumping the gun. It would be akin to supporting read-only syntax for properties even though it doesn't really exist in the language yet. I am willing to change this if you want though.