### PR TITLE
Add optional "u" to "lua" for markdown comments

### DIFF
--- a/Luau.YAML-tmLanguage
+++ b/Luau.YAML-tmLanguage
@@ -270,7 +270,7 @@ repository:
         end: "\\]\\1\\]"
         patterns:
           - name: keyword.operator.other.luau
-            begin: "(```lua)\\s+"
+            begin: "(```luau?)\\s+"
             end: "(```)"
             beginCaptures:
               "1": { name: comment.luau }

--- a/Luau.tmLanguage
+++ b/Luau.tmLanguage
@@ -760,7 +760,7 @@
                 <key>name</key>
                 <string>keyword.operator.other.luau</string>
                 <key>begin</key>
-                <string>(```lua)\s+</string>
+                <string>(```luau?)\s+</string>
                 <key>end</key>
                 <string>(```)</string>
                 <key>beginCaptures</key>

--- a/Luau.tmLanguage.json
+++ b/Luau.tmLanguage.json
@@ -500,7 +500,7 @@
           "patterns": [
             {
               "name": "keyword.operator.other.luau",
-              "begin": "(```lua)\\s+",
+              "begin": "(```luau?)\\s+",
               "end": "(```)",
               "beginCaptures": {
                 "1": {

--- a/tests/baselines/markdown-luau-language.baseline.txt
+++ b/tests/baselines/markdown-luau-language.baseline.txt
@@ -1,0 +1,108 @@
+original file
+-----------------------------------
+--[[
+```luau
+local abc: number = 1
+print(abc)
+```
+]]
+
+--[[
+```lua
+local abc: number = 1
+print(abc)
+```
+]]
+
+-----------------------------------
+
+>--[[
+ ^^^^
+ source.luau comment.block.luau
+>```luau
+ ^^^^^^^
+ source.luau comment.block.luau keyword.operator.other.luau comment.luau
+>local abc: number = 1
+ ^^^^^
+ source.luau comment.block.luau keyword.operator.other.luau storage.modifier.local.luau
+      ^
+      source.luau comment.block.luau keyword.operator.other.luau
+       ^^^
+       source.luau comment.block.luau keyword.operator.other.luau variable.other.readwrite.luau
+          ^
+          source.luau comment.block.luau keyword.operator.other.luau keyword.operator.type.luau
+           ^
+           source.luau comment.block.luau keyword.operator.other.luau
+            ^^^^^^
+            source.luau comment.block.luau keyword.operator.other.luau support.type.primitive.luau
+                  ^
+                  source.luau comment.block.luau keyword.operator.other.luau
+                   ^
+                   source.luau comment.block.luau keyword.operator.other.luau keyword.operator.assignment.luau
+                    ^
+                    source.luau comment.block.luau keyword.operator.other.luau
+                     ^
+                     source.luau comment.block.luau keyword.operator.other.luau constant.numeric.decimal.luau
+>print(abc)
+ ^^^^^
+ source.luau comment.block.luau keyword.operator.other.luau support.function.luau
+      ^
+      source.luau comment.block.luau keyword.operator.other.luau punctuation.arguments.begin.luau
+       ^^^
+       source.luau comment.block.luau keyword.operator.other.luau variable.other.readwrite.luau
+          ^
+          source.luau comment.block.luau keyword.operator.other.luau punctuation.arguments.end.luau
+>```
+ ^^^
+ source.luau comment.block.luau keyword.operator.other.luau comment.luau
+>]]
+ ^^
+ source.luau comment.block.luau
+>
+ ^
+ source.luau
+>--[[
+ ^^^^
+ source.luau comment.block.luau
+>```lua
+ ^^^^^^
+ source.luau comment.block.luau keyword.operator.other.luau comment.luau
+>local abc: number = 1
+ ^^^^^
+ source.luau comment.block.luau keyword.operator.other.luau storage.modifier.local.luau
+      ^
+      source.luau comment.block.luau keyword.operator.other.luau
+       ^^^
+       source.luau comment.block.luau keyword.operator.other.luau variable.other.readwrite.luau
+          ^
+          source.luau comment.block.luau keyword.operator.other.luau keyword.operator.type.luau
+           ^
+           source.luau comment.block.luau keyword.operator.other.luau
+            ^^^^^^
+            source.luau comment.block.luau keyword.operator.other.luau support.type.primitive.luau
+                  ^
+                  source.luau comment.block.luau keyword.operator.other.luau
+                   ^
+                   source.luau comment.block.luau keyword.operator.other.luau keyword.operator.assignment.luau
+                    ^
+                    source.luau comment.block.luau keyword.operator.other.luau
+                     ^
+                     source.luau comment.block.luau keyword.operator.other.luau constant.numeric.decimal.luau
+>print(abc)
+ ^^^^^
+ source.luau comment.block.luau keyword.operator.other.luau support.function.luau
+      ^
+      source.luau comment.block.luau keyword.operator.other.luau punctuation.arguments.begin.luau
+       ^^^
+       source.luau comment.block.luau keyword.operator.other.luau variable.other.readwrite.luau
+          ^
+          source.luau comment.block.luau keyword.operator.other.luau punctuation.arguments.end.luau
+>```
+ ^^^
+ source.luau comment.block.luau keyword.operator.other.luau comment.luau
+>]]
+ ^^
+ source.luau comment.block.luau
+>
+ ^
+ source.luau

--- a/tests/cases/markdown-luau-language.luau
+++ b/tests/cases/markdown-luau-language.luau
@@ -1,0 +1,13 @@
+--[[
+```luau
+local abc: number = 1
+print(abc)
+```
+]]
+
+--[[
+```lua
+local abc: number = 1
+print(abc)
+```
+]]


### PR DESCRIPTION
tin

fixes \`\`\`luau not working