### PR TITLE
Add syntax highlighting support for the const keyword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 build/*.js
+build/*.tsbuildinfo
 tests/*.js
 tests/generated/*
 xunit.xml

--- a/Luau.YAML-tmLanguage
+++ b/Luau.YAML-tmLanguage
@@ -12,7 +12,7 @@ fileTypes: [luau]
 
 variables:
   matchingParentheses: (\(([^\(\)]|(\(([^\(\)]|\([^\(\)]*\))*\)))*\))
-  lookAheadEndOfType: '(?=[),}\]](?!\s*[&|]))|(?=\s*;)|(?=\s*\b(?:break|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*{{identifier}}(?:\.{{identifier}})*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))'
+  lookAheadEndOfType: '(?=[),}\]](?!\s*[&|]))|(?=\s*;)|(?=\s*\b(?:break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*{{identifier}}(?:\.{{identifier}})*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))'
   identifier: "[a-zA-Z_][a-zA-Z0-9_]*"
 
 patterns:
@@ -22,6 +22,7 @@ patterns:
   - include: "#shebang"
   - include: "#comment"
   - include: "#local-declaration"
+  - include: "#const-declaration"
   - include: "#for-loop"
   - include: "#type-function"
   - include: "#type-alias-declaration"
@@ -39,7 +40,7 @@ patterns:
 
 repository:
   function-definition:
-    begin: "\\b(?:(local)\\s+)?(function)\\b(?![,:])"
+    begin: "\\b(?:(local|const)\\s+)?(function)\\b(?![,:])"
     beginCaptures:
       "1": { name: storage.modifier.local.luau } # OLD: keyword.local.luau
       "2": { name: keyword.control.luau }
@@ -91,6 +92,25 @@ repository:
       - name: variable.other.constant.luau
         match: "\\b([A-Z_][A-Z0-9_]*)\\b"
       - name: variable.other.readwrite.luau # TODO: should this be something different? old was just variable.other.luau
+        match: "\\b({{identifier}})\\b"
+
+  const-declaration:
+    begin: "\\b(const)\\b"
+    end: "(?=\\s*[=;]|\\s*$)"
+    beginCaptures:
+      "1": { name: storage.modifier.local.luau }
+    patterns:
+      - include: "#comment"
+      - include: "#attribute"
+      - begin: "(:)"
+        beginCaptures:
+          "1": { name: keyword.operator.type.luau }
+        end: "(?=\\s*[=;,]|\\s*$)"
+        patterns:
+          - include: "#type_literal"
+      - name: variable.other.constant.luau
+        match: "\\b([A-Z_][A-Z0-9_]*)\\b"
+      - name: variable.other.readwrite.luau
         match: "\\b({{identifier}})\\b"
 
   for-loop:
@@ -197,7 +217,7 @@ repository:
     patterns:
       - match: "\\b(break|do|else|for|if|elseif|return|then|repeat|while|until|end|in|continue)\\b"
         name: keyword.control.luau
-      - match: "\\b(local)\\b"
+      - match: "\\b(local|const)\\b"
         name: storage.modifier.local.luau
       - match: "\\b(function)\\b(?![,:])"
         name: keyword.control.luau

--- a/Luau.YAML-tmLanguage
+++ b/Luau.YAML-tmLanguage
@@ -40,10 +40,11 @@ patterns:
 
 repository:
   function-definition:
-    begin: "\\b(?:(local|const)\\s+)?(function)\\b(?![,:])"
+    begin: "\\b(?:(local)\\s+|(const)\\s+)?(function)\\b(?![,:])"
     beginCaptures:
       "1": { name: storage.modifier.local.luau } # OLD: keyword.local.luau
-      "2": { name: keyword.control.luau }
+      "2": { name: storage.modifier.const.luau }
+      "3": { name: keyword.control.luau }
     end: "(?<=[\\)\\-{}\\[\\]\"'])"
     name: meta.function.luau
     patterns:
@@ -98,7 +99,7 @@ repository:
     begin: "\\b(const)\\b"
     end: "(?=\\s*[=;]|\\s*$)"
     beginCaptures:
-      "1": { name: storage.modifier.local.luau }
+      "1": { name: storage.modifier.const.luau }
     patterns:
       - include: "#comment"
       - include: "#attribute"
@@ -217,8 +218,10 @@ repository:
     patterns:
       - match: "\\b(break|do|else|for|if|elseif|return|then|repeat|while|until|end|in|continue)\\b"
         name: keyword.control.luau
-      - match: "\\b(local|const)\\b"
+      - match: "\\b(local)\\b"
         name: storage.modifier.local.luau
+      - match: "\\b(const)\\b"
+        name: storage.modifier.const.luau
       - match: "\\b(function)\\b(?![,:])"
         name: keyword.control.luau
       - match: "(?<![^.]\\.|:)\\b(self)\\b"

--- a/Luau.tmLanguage
+++ b/Luau.tmLanguage
@@ -108,7 +108,7 @@
       <key>function-definition</key>
       <dict>
         <key>begin</key>
-        <string>\b(?:(local|const)\s+)?(function)\b(?![,:])</string>
+        <string>\b(?:(local)\s+|(const)\s+)?(function)\b(?![,:])</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -117,6 +117,11 @@
             <string>storage.modifier.local.luau</string>
           </dict>
           <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>storage.modifier.const.luau</string>
+          </dict>
+          <key>3</key>
           <dict>
             <key>name</key>
             <string>keyword.control.luau</string>
@@ -290,7 +295,7 @@
           <key>1</key>
           <dict>
             <key>name</key>
-            <string>storage.modifier.local.luau</string>
+            <string>storage.modifier.const.luau</string>
           </dict>
         </dict>
         <key>patterns</key>
@@ -622,9 +627,15 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>\b(local|const)\b</string>
+            <string>\b(local)\b</string>
             <key>name</key>
             <string>storage.modifier.local.luau</string>
+          </dict>
+          <dict>
+            <key>match</key>
+            <string>\b(const)\b</string>
+            <key>name</key>
+            <string>storage.modifier.const.luau</string>
           </dict>
           <dict>
             <key>match</key>

--- a/Luau.tmLanguage
+++ b/Luau.tmLanguage
@@ -44,6 +44,10 @@
       </dict>
       <dict>
         <key>include</key>
+        <string>#const-declaration</string>
+      </dict>
+      <dict>
+        <key>include</key>
         <string>#for-loop</string>
       </dict>
       <dict>
@@ -104,7 +108,7 @@
       <key>function-definition</key>
       <dict>
         <key>begin</key>
-        <string>\b(?:(local)\s+)?(function)\b(?![,:])</string>
+        <string>\b(?:(local|const)\s+)?(function)\b(?![,:])</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -253,6 +257,65 @@
             </dict>
             <key>end</key>
             <string>(?=\s*do\b|\s*[=;,]|\s*$)</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#type_literal</string>
+              </dict>
+            </array>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>variable.other.constant.luau</string>
+            <key>match</key>
+            <string>\b([A-Z_][A-Z0-9_]*)\b</string>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>variable.other.readwrite.luau</string>
+            <key>match</key>
+            <string>\b([a-zA-Z_][a-zA-Z0-9_]*)\b</string>
+          </dict>
+        </array>
+      </dict>
+      <key>const-declaration</key>
+      <dict>
+        <key>begin</key>
+        <string>\b(const)\b</string>
+        <key>end</key>
+        <string>(?=\s*[=;]|\s*$)</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>storage.modifier.local.luau</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#comment</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#attribute</string>
+          </dict>
+          <dict>
+            <key>begin</key>
+            <string>(:)</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>keyword.operator.type.luau</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(?=\s*[=;,]|\s*$)</string>
             <key>patterns</key>
             <array>
               <dict>
@@ -559,7 +622,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>\b(local)\b</string>
+            <string>\b(local|const)\b</string>
             <key>name</key>
             <string>storage.modifier.local.luau</string>
           </dict>
@@ -1040,7 +1103,7 @@
         <key>begin</key>
         <string>(?&lt;![^.]\.|:)\b(?:(export)\s+)?(type)\b(?=\s+(?!function\b)[a-zA-Z_][a-zA-Z0-9_]*)</string>
         <key>end</key>
-        <string>(?=[),}\]](?!\s*[&amp;|]))|(?=\s*;)|(?=\s*\b(?:break|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))</string>
+        <string>(?=[),}\]](?!\s*[&amp;|]))|(?=\s*;)|(?=\s*\b(?:break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -1099,7 +1162,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?=[),}\]](?!\s*[&amp;|]))|(?=\s*;)|(?=\s*\b(?:break|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))</string>
+        <string>(?=[),}\]](?!\s*[&amp;|]))|(?=\s*;)|(?=\s*\b(?:break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))</string>
         <key>patterns</key>
         <array>
           <dict>

--- a/Luau.tmLanguage.json
+++ b/Luau.tmLanguage.json
@@ -29,6 +29,9 @@
       "include": "#local-declaration"
     },
     {
+      "include": "#const-declaration"
+    },
+    {
       "include": "#for-loop"
     },
     {
@@ -73,7 +76,7 @@
   ],
   "repository": {
     "function-definition": {
-      "begin": "\\b(?:(local)\\s+)?(function)\\b(?![,:])",
+      "begin": "\\b(?:(local|const)\\s+)?(function)\\b(?![,:])",
       "beginCaptures": {
         "1": {
           "name": "storage.modifier.local.luau"
@@ -170,6 +173,45 @@
             }
           },
           "end": "(?=\\s*do\\b|\\s*[=;,]|\\s*$)",
+          "patterns": [
+            {
+              "include": "#type_literal"
+            }
+          ]
+        },
+        {
+          "name": "variable.other.constant.luau",
+          "match": "\\b([A-Z_][A-Z0-9_]*)\\b"
+        },
+        {
+          "name": "variable.other.readwrite.luau",
+          "match": "\\b([a-zA-Z_][a-zA-Z0-9_]*)\\b"
+        }
+      ]
+    },
+    "const-declaration": {
+      "begin": "\\b(const)\\b",
+      "end": "(?=\\s*[=;]|\\s*$)",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.modifier.local.luau"
+        }
+      },
+      "patterns": [
+        {
+          "include": "#comment"
+        },
+        {
+          "include": "#attribute"
+        },
+        {
+          "begin": "(:)",
+          "beginCaptures": {
+            "1": {
+              "name": "keyword.operator.type.luau"
+            }
+          },
+          "end": "(?=\\s*[=;,]|\\s*$)",
           "patterns": [
             {
               "include": "#type_literal"
@@ -370,7 +412,7 @@
           "name": "keyword.control.luau"
         },
         {
-          "match": "\\b(local)\\b",
+          "match": "\\b(local|const)\\b",
           "name": "storage.modifier.local.luau"
         },
         {
@@ -684,7 +726,7 @@
     },
     "type-alias-declaration": {
       "begin": "(?<![^.]\\.|:)\\b(?:(export)\\s+)?(type)\\b(?=\\s+(?!function\\b)[a-zA-Z_][a-zA-Z0-9_]*)",
-      "end": "(?=[),}\\]](?!\\s*[&|]))|(?=\\s*;)|(?=\\s*\\b(?:break|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\\b)|(?=^\\s*$)|(?=^\\s*(?:@|\\b(?:export\\s+)?type\\b))|(?=^\\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*\\s*(?:(?:[+\\-*/%^]|\\.\\.)?=(?!=)|\\(|\\[|:))",
+      "end": "(?=[),}\\]](?!\\s*[&|]))|(?=\\s*;)|(?=\\s*\\b(?:break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\\b)|(?=^\\s*$)|(?=^\\s*(?:@|\\b(?:export\\s+)?type\\b))|(?=^\\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*\\s*(?:(?:[+\\-*/%^]|\\.\\.)?=(?!=)|\\(|\\[|:))",
       "beginCaptures": {
         "1": {
           "name": "storage.modifier.visibility.luau"
@@ -722,7 +764,7 @@
           "name": "keyword.operator.typecast.luau"
         }
       },
-      "end": "(?=[),}\\]](?!\\s*[&|]))|(?=\\s*;)|(?=\\s*\\b(?:break|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\\b)|(?=^\\s*$)|(?=^\\s*(?:@|\\b(?:export\\s+)?type\\b))|(?=^\\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*\\s*(?:(?:[+\\-*/%^]|\\.\\.)?=(?!=)|\\(|\\[|:))",
+      "end": "(?=[),}\\]](?!\\s*[&|]))|(?=\\s*;)|(?=\\s*\\b(?:break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\\b)|(?=^\\s*$)|(?=^\\s*(?:@|\\b(?:export\\s+)?type\\b))|(?=^\\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*\\s*(?:(?:[+\\-*/%^]|\\.\\.)?=(?!=)|\\(|\\[|:))",
       "patterns": [
         {
           "include": "#type_literal"

--- a/Luau.tmLanguage.json
+++ b/Luau.tmLanguage.json
@@ -76,12 +76,15 @@
   ],
   "repository": {
     "function-definition": {
-      "begin": "\\b(?:(local|const)\\s+)?(function)\\b(?![,:])",
+      "begin": "\\b(?:(local)\\s+|(const)\\s+)?(function)\\b(?![,:])",
       "beginCaptures": {
         "1": {
           "name": "storage.modifier.local.luau"
         },
         "2": {
+          "name": "storage.modifier.const.luau"
+        },
+        "3": {
           "name": "keyword.control.luau"
         }
       },
@@ -194,7 +197,7 @@
       "end": "(?=\\s*[=;]|\\s*$)",
       "beginCaptures": {
         "1": {
-          "name": "storage.modifier.local.luau"
+          "name": "storage.modifier.const.luau"
         }
       },
       "patterns": [
@@ -412,8 +415,12 @@
           "name": "keyword.control.luau"
         },
         {
-          "match": "\\b(local|const)\\b",
+          "match": "\\b(local)\\b",
           "name": "storage.modifier.local.luau"
+        },
+        {
+          "match": "\\b(const)\\b",
+          "name": "storage.modifier.const.luau"
         },
         {
           "match": "\\b(function)\\b(?![,:])",

--- a/tests/baselines/const-declaration.baseline.txt
+++ b/tests/baselines/const-declaration.baseline.txt
@@ -1,0 +1,96 @@
+original file
+-----------------------------------
+const x = 5
+const MY_CONST = "hello"
+const y: number = 10
+const function foo()
+  return 1
+end
+
+-----------------------------------
+
+>const x = 5
+ ^^^^^
+ source.luau storage.modifier.local.luau
+      ^
+      source.luau
+       ^
+       source.luau variable.other.readwrite.luau
+        ^
+        source.luau
+         ^
+         source.luau keyword.operator.assignment.luau
+          ^
+          source.luau
+           ^
+           source.luau constant.numeric.decimal.luau
+>const MY_CONST = "hello"
+ ^^^^^
+ source.luau storage.modifier.local.luau
+      ^
+      source.luau
+       ^^^^^^^^
+       source.luau variable.other.constant.luau
+               ^
+               source.luau
+                ^
+                source.luau keyword.operator.assignment.luau
+                 ^
+                 source.luau
+                  ^
+                  source.luau string.quoted.double.luau
+                   ^^^^^
+                   source.luau string.quoted.double.luau
+                        ^
+                        source.luau string.quoted.double.luau
+>const y: number = 10
+ ^^^^^
+ source.luau storage.modifier.local.luau
+      ^
+      source.luau
+       ^
+       source.luau variable.other.readwrite.luau
+        ^
+        source.luau keyword.operator.type.luau
+         ^
+         source.luau
+          ^^^^^^
+          source.luau support.type.primitive.luau
+                ^
+                source.luau
+                 ^
+                 source.luau keyword.operator.assignment.luau
+                  ^
+                  source.luau
+                   ^^
+                   source.luau constant.numeric.decimal.luau
+>const function foo()
+ ^^^^^
+ source.luau meta.function.luau storage.modifier.local.luau
+      ^
+      source.luau meta.function.luau
+       ^^^^^^^^
+       source.luau meta.function.luau keyword.control.luau
+               ^
+               source.luau meta.function.luau
+                ^^^
+                source.luau meta.function.luau entity.name.function.luau
+                   ^
+                   source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.begin.luau
+                    ^
+                    source.luau meta.function.luau meta.parameter.luau punctuation.definition.parameters.end.luau
+>  return 1
+ ^^
+ source.luau
+   ^^^^^^
+   source.luau keyword.control.luau
+         ^
+         source.luau
+          ^
+          source.luau constant.numeric.decimal.luau
+>end
+ ^^^
+ source.luau keyword.control.luau
+>
+ ^
+ source.luau

--- a/tests/baselines/const-declaration.baseline.txt
+++ b/tests/baselines/const-declaration.baseline.txt
@@ -11,7 +11,7 @@ end
 
 >const x = 5
  ^^^^^
- source.luau storage.modifier.local.luau
+ source.luau storage.modifier.const.luau
       ^
       source.luau
        ^
@@ -26,7 +26,7 @@ end
            source.luau constant.numeric.decimal.luau
 >const MY_CONST = "hello"
  ^^^^^
- source.luau storage.modifier.local.luau
+ source.luau storage.modifier.const.luau
       ^
       source.luau
        ^^^^^^^^
@@ -45,7 +45,7 @@ end
                         source.luau string.quoted.double.luau
 >const y: number = 10
  ^^^^^
- source.luau storage.modifier.local.luau
+ source.luau storage.modifier.const.luau
       ^
       source.luau
        ^
@@ -66,7 +66,7 @@ end
                    source.luau constant.numeric.decimal.luau
 >const function foo()
  ^^^^^
- source.luau meta.function.luau storage.modifier.local.luau
+ source.luau meta.function.luau storage.modifier.const.luau
       ^
       source.luau meta.function.luau
        ^^^^^^^^

--- a/tests/cases/const-declaration.luau
+++ b/tests/cases/const-declaration.luau
@@ -1,0 +1,6 @@
+const x = 5
+const MY_CONST = "hello"
+const y: number = 10
+const function foo()
+	return 1
+end


### PR DESCRIPTION
Treats const similarly to local: storage.modifier.local.luau scope for
the keyword, const function declarations, const variable declarations
with type annotations, and fallback keyword matching.

Adds const-declaration.luau test case with accepted baseline.