### PR TITLE
fix: end type cast at arithmetic/comparison operators

### DIFF
--- a/Luau.YAML-tmLanguage
+++ b/Luau.YAML-tmLanguage
@@ -12,7 +12,7 @@ fileTypes: [luau]
 
 variables:
   matchingParentheses: (\(([^\(\)]|(\(([^\(\)]|\([^\(\)]*\))*\)))*\))
-  lookAheadEndOfType: '(?=[),}\]](?!\s*[&|]))|(?=\s*;)|(?=\s*\b(?:break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*{{identifier}}(?:\.{{identifier}})*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))'
+  lookAheadEndOfType: '(?=[),}\]](?!\s*[&|]))|(?=\s*;)|(?=\s*(?:[*+%^]|\/\/?|(?<!\.)\.\.(?!\.)|-(?![->`])|~=|==))|(?=\s*\b(?:and|or|break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*{{identifier}}(?:\.{{identifier}})*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))'
   identifier: "[a-zA-Z_][a-zA-Z0-9_]*"
 
 patterns:

--- a/Luau.YAML-tmLanguage
+++ b/Luau.YAML-tmLanguage
@@ -12,8 +12,15 @@ fileTypes: [luau]
 
 variables:
   matchingParentheses: (\(([^\(\)]|(\(([^\(\)]|\([^\(\)]*\))*\)))*\))
-  lookAheadEndOfType: '(?=[),}\]](?!\s*[&|]))|(?=\s*;)|(?=\s*(?:[*+%^]|\/\/?|(?<!\.)\.\.(?!\.)|-(?![->`])|~=|==))|(?=\s*\b(?:and|or|break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*{{identifier}}(?:\.{{identifier}})*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))'
   identifier: "[a-zA-Z_][a-zA-Z0-9_]*"
+  # Arithmetic/comparison operators that are valid in expressions but cannot appear at the
+  # top level of a Luau type expression, so their presence signals the end of a type.
+  # Exclusions: ->  (function return type arrow), --  (comment), ...  (variadic pack)
+  nonTypeOperators: '[*+%^]|\/\/?|(?<!\.)\.\.(?!\.)|-(?![->`])|~=|=='
+  # Keywords that are valid outside a type expression (as binary operators or statement
+  # starters) but cannot appear within one, so their presence signals the end of a type.
+  nonTypeKeywords: 'and|or|break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while'
+  lookAheadEndOfType: '(?=[),}\]](?!\s*[&|]))|(?=\s*;)|(?=\s*(?:{{nonTypeOperators}}))|(?=\s*\b(?:{{nonTypeKeywords}})\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*{{identifier}}(?:\.{{identifier}})*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))'
 
 patterns:
   - include: "#function-definition"

--- a/Luau.tmLanguage
+++ b/Luau.tmLanguage
@@ -1114,7 +1114,7 @@
         <key>begin</key>
         <string>(?&lt;![^.]\.|:)\b(?:(export)\s+)?(type)\b(?=\s+(?!function\b)[a-zA-Z_][a-zA-Z0-9_]*)</string>
         <key>end</key>
-        <string>(?=[),}\]](?!\s*[&amp;|]))|(?=\s*;)|(?=\s*\b(?:break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))</string>
+        <string>(?=[),}\]](?!\s*[&amp;|]))|(?=\s*;)|(?=\s*(?:[*+%^]|\/\/?|(?&lt;!\.)\.\.(?!\.)|-(?![-&gt;`])|~=|==))|(?=\s*\b(?:and|or|break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -1173,7 +1173,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?=[),}\]](?!\s*[&amp;|]))|(?=\s*;)|(?=\s*\b(?:break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))</string>
+        <string>(?=[),}\]](?!\s*[&amp;|]))|(?=\s*;)|(?=\s*(?:[*+%^]|\/\/?|(?&lt;!\.)\.\.(?!\.)|-(?![-&gt;`])|~=|==))|(?=\s*\b(?:and|or|break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\b)|(?=^\s*$)|(?=^\s*(?:@|\b(?:export\s+)?type\b))|(?=^\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*\s*(?:(?:[+\-*/%^]|\.\.)?=(?!=)|\(|\[|:))</string>
         <key>patterns</key>
         <array>
           <dict>

--- a/Luau.tmLanguage.json
+++ b/Luau.tmLanguage.json
@@ -733,7 +733,7 @@
     },
     "type-alias-declaration": {
       "begin": "(?<![^.]\\.|:)\\b(?:(export)\\s+)?(type)\\b(?=\\s+(?!function\\b)[a-zA-Z_][a-zA-Z0-9_]*)",
-      "end": "(?=[),}\\]](?!\\s*[&|]))|(?=\\s*;)|(?=\\s*\\b(?:break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\\b)|(?=^\\s*$)|(?=^\\s*(?:@|\\b(?:export\\s+)?type\\b))|(?=^\\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*\\s*(?:(?:[+\\-*/%^]|\\.\\.)?=(?!=)|\\(|\\[|:))",
+      "end": "(?=[),}\\]](?!\\s*[&|]))|(?=\\s*;)|(?=\\s*(?:[*+%^]|\\/\\/?|(?<!\\.)\\.\\.(?!\\.)|-(?![->`])|~=|==))|(?=\\s*\\b(?:and|or|break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\\b)|(?=^\\s*$)|(?=^\\s*(?:@|\\b(?:export\\s+)?type\\b))|(?=^\\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*\\s*(?:(?:[+\\-*/%^]|\\.\\.)?=(?!=)|\\(|\\[|:))",
       "beginCaptures": {
         "1": {
           "name": "storage.modifier.visibility.luau"
@@ -771,7 +771,7 @@
           "name": "keyword.operator.typecast.luau"
         }
       },
-      "end": "(?=[),}\\]](?!\\s*[&|]))|(?=\\s*;)|(?=\\s*\\b(?:break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\\b)|(?=^\\s*$)|(?=^\\s*(?:@|\\b(?:export\\s+)?type\\b))|(?=^\\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*\\s*(?:(?:[+\\-*/%^]|\\.\\.)?=(?!=)|\\(|\\[|:))",
+      "end": "(?=[),}\\]](?!\\s*[&|]))|(?=\\s*;)|(?=\\s*(?:[*+%^]|\\/\\/?|(?<!\\.)\\.\\.(?!\\.)|-(?![->`])|~=|==))|(?=\\s*\\b(?:and|or|break|const|continue|do|else|elseif|end|for|function|if|in|local|repeat|return|then|until|while)\\b)|(?=^\\s*$)|(?=^\\s*(?:@|\\b(?:export\\s+)?type\\b))|(?=^\\s*[a-zA-Z_][a-zA-Z0-9_]*(?:\\.[a-zA-Z_][a-zA-Z0-9_]*)*\\s*(?:(?:[+\\-*/%^]|\\.\\.)?=(?!=)|\\(|\\[|:))",
       "patterns": [
         {
           "include": "#type_literal"

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES5",
+    "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "strict": true,
     "skipLibCheck": true

--- a/build/tsconfig.json
+++ b/build/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "ES5",
-    "ignoreDeprecations": "6.0",
     "module": "commonjs",
     "strict": true,
     "skipLibCheck": true

--- a/tests/baselines/issue-24.baseline.txt
+++ b/tests/baselines/issue-24.baseline.txt
@@ -1,7 +1,6 @@
 original file
 -----------------------------------
 local a = tonumber("1")::number * 1000
-print(a)
 
 -----------------------------------
 
@@ -42,15 +41,6 @@ print(a)
                                   source.luau
                                    ^^^^
                                    source.luau constant.numeric.decimal.luau
->print(a)
- ^^^^^
- source.luau support.function.luau
-      ^
-      source.luau punctuation.arguments.begin.luau
-       ^
-       source.luau variable.other.readwrite.luau
-        ^
-        source.luau punctuation.arguments.end.luau
 >
  ^
  source.luau

--- a/tests/baselines/issue-24.baseline.txt
+++ b/tests/baselines/issue-24.baseline.txt
@@ -1,0 +1,56 @@
+original file
+-----------------------------------
+local a = tonumber("1")::number * 1000
+print(a)
+
+-----------------------------------
+
+>local a = tonumber("1")::number * 1000
+ ^^^^^
+ source.luau storage.modifier.local.luau
+      ^
+      source.luau
+       ^
+       source.luau variable.other.readwrite.luau
+        ^
+        source.luau
+         ^
+         source.luau keyword.operator.assignment.luau
+          ^
+          source.luau
+           ^^^^^^^^
+           source.luau support.function.luau
+                   ^
+                   source.luau punctuation.arguments.begin.luau
+                    ^
+                    source.luau string.quoted.double.luau
+                     ^
+                     source.luau string.quoted.double.luau
+                      ^
+                      source.luau string.quoted.double.luau
+                       ^
+                       source.luau punctuation.arguments.end.luau
+                        ^^
+                        source.luau keyword.operator.typecast.luau
+                          ^^^^^^
+                          source.luau support.type.primitive.luau
+                                ^
+                                source.luau
+                                 ^
+                                 source.luau keyword.operator.arithmetic.luau
+                                  ^
+                                  source.luau
+                                   ^^^^
+                                   source.luau constant.numeric.decimal.luau
+>print(a)
+ ^^^^^
+ source.luau support.function.luau
+      ^
+      source.luau punctuation.arguments.begin.luau
+       ^
+       source.luau variable.other.readwrite.luau
+        ^
+        source.luau punctuation.arguments.end.luau
+>
+ ^
+ source.luau

--- a/tests/baselines/stylua-luau-assignment-hang-1.lua.baseline.txt
+++ b/tests/baselines/stylua-luau-assignment-hang-1.lua.baseline.txt
@@ -450,10 +450,14 @@ exports.separateDisplayNameAndHOCs =
                          source.luau
                           ^^^
                           source.luau support.type.primitive.luau
-                             ^^^^
+                             ^
                              source.luau
+                              ^^
+                              source.luau keyword.operator.comparison.luau
+                                ^
+                                source.luau
                                  ^^^
-                                 source.luau support.type.primitive.luau
+                                 source.luau constant.language.nil.luau
                                     ^
                                     source.luau
                                      ^^

--- a/tests/cases/issue-24.luau
+++ b/tests/cases/issue-24.luau
@@ -1,2 +1,1 @@
 local a = tonumber("1")::number * 1000
-print(a)

--- a/tests/cases/issue-24.luau
+++ b/tests/cases/issue-24.luau
@@ -1,0 +1,2 @@
+local a = tonumber("1")::number * 1000
+print(a)


### PR DESCRIPTION
Highlighting was lost after a type cast when followed by arithmetic
operators like `*`, because `lookAheadEndOfType` didn't recognize those
operators as terminators for the type expression.

Add binary arithmetic operators (`*`, `+`, `%`, `^`, `/`, `//`, `..`,
`-`, `~=`, `==`) and logical keywords (`and`, `or`) to `lookAheadEndOfType`
so that `expr::Type * value` correctly ends the type cast at `*`.

Care is taken to avoid false positives:
- `-(?![->\`])` prevents matching `--` (comments) or `->` (function types)
- `(?<!\.)\.\.(?!\.)` prevents matching `..` inside `...` (variadics)

Fixes https://github.com/JohnnyMorganz/Luau.tmLanguage/issues/24