### PR TITLE
`!=` is not a real luau operator

### DIFF
--- a/Luau.YAML-tmLanguage
+++ b/Luau.YAML-tmLanguage
@@ -253,7 +253,7 @@ repository:
 
   operator:
     patterns:
-      - match: "==|~=|!=|<=?|>=?"
+      - match: "==|~=|<=?|>=?"
         name: keyword.operator.comparison.luau
       - match: "\\+=|-=|/=|//=|\\*=|%=|\\^=|\\.\\.=|="
         name: keyword.operator.assignment.luau

--- a/Luau.tmLanguage
+++ b/Luau.tmLanguage
@@ -705,7 +705,7 @@
         <array>
           <dict>
             <key>match</key>
-            <string>==|~=|!=|&lt;=?|&gt;=?</string>
+            <string>==|~=|&lt;=?|&gt;=?</string>
             <key>name</key>
             <string>keyword.operator.comparison.luau</string>
           </dict>

--- a/Luau.tmLanguage.json
+++ b/Luau.tmLanguage.json
@@ -467,7 +467,7 @@
     "operator": {
       "patterns": [
         {
-          "match": "==|~=|!=|<=?|>=?",
+          "match": "==|~=|<=?|>=?",
           "name": "keyword.operator.comparison.luau"
         },
         {


### PR DESCRIPTION
```lua
> print(0 != 1)
stdin:1: Unexpected '!='; did you mean '~='?
```