### PR TITLE
`userdata` and `symbol` are not real types

### DIFF
--- a/Luau.YAML-tmLanguage
+++ b/Luau.YAML-tmLanguage
@@ -433,7 +433,7 @@ repository:
         name: constant.language.boolean.false.luau
       - match: "\\b(true)\\b"
         name: constant.language.boolean.true.luau
-      - match: "\\b(nil|string|number|boolean|thread|userdata|symbol|vector|buffer|unknown|never|any)\\b"
+      - match: "\\b(nil|string|number|boolean|thread|vector|buffer|unknown|never|any)\\b"
         name: support.type.primitive.luau
       - begin: "\\b(typeof)\\b(\\()" # TODO: assign scope to punctuation?
         beginCaptures:

--- a/Luau.tmLanguage
+++ b/Luau.tmLanguage
@@ -1220,7 +1220,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>\b(nil|string|number|boolean|thread|userdata|symbol|vector|buffer|unknown|never|any)\b</string>
+            <string>\b(nil|string|number|boolean|thread|vector|buffer|unknown|never|any)\b</string>
             <key>name</key>
             <string>support.type.primitive.luau</string>
           </dict>

--- a/Luau.tmLanguage.json
+++ b/Luau.tmLanguage.json
@@ -803,7 +803,7 @@
           "name": "constant.language.boolean.true.luau"
         },
         {
-          "match": "\\b(nil|string|number|boolean|thread|userdata|symbol|vector|buffer|unknown|never|any)\\b",
+          "match": "\\b(nil|string|number|boolean|thread|vector|buffer|unknown|never|any)\\b",
           "name": "support.type.primitive.luau"
         },
         {


### PR DESCRIPTION
```
$ ./luau/luau-analyze typetest.luau 
./typetest.luau(6,11): TypeError: Unknown type 'userdata'
./typetest.luau(7,11): TypeError: Unknown type 'symbol'
$ cat typetest.luau 
```
```luau
local _a: nil
local _b: string
local _c: number
local _d: boolean
local _e: thread
local _f: userdata
local _g: symbol
local _h: vector
local _i: buffer
local _j: unknown
local _k: never
local _l: any
```
